### PR TITLE
시간을 좀 더 정확하게 계산하도록 수정

### DIFF
--- a/to-the-king.html
+++ b/to-the-king.html
@@ -37,7 +37,7 @@
 <body>
     <div id="to-the-king-clock"></div>
     <script>
-        var time = 0;
+        var startTime = new Date();
         var clock = document.getElementById("to-the-king-clock");
 
         var formTime = function(time) {
@@ -48,6 +48,7 @@
         };
 
         var setTime = function () {
+            var time = Math.floor((new Date() - startTime)/1000)
             var sec = time % 60;
             var minute =  Math.floor(time / 60 % (60));
             var hour = Math.floor(time / (60 * 60));
@@ -55,8 +56,8 @@
             clock.innerText = formTime(hour) + ":" + formTime(minute) + ":" + formTime(sec);
         };
 
+        setTime();
         setInterval(function () {
-            time += 1;
             setTime();
         }, 1000);
     </script>


### PR DESCRIPTION
- setInterval에서 발생할 수 있는 오차를 제거하기 위해 기준 시각(스크립트 로드 시각)으로부터 지난 시간을 계산해서 시간을 표시하도록 수정
- 시간이 0초부터 표시 되도록 수정